### PR TITLE
Add logic to handle array responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,6 +92,16 @@ function translate (text, opts, gotopts)
 
       const body = JSON.parse(res.body);
 
+      if (typeof body.sentences === "undefined") {
+         if (Array.isArray(body)) {
+            result.text = body[0];
+            result.from.language.iso = opts.from;
+            result.from.text.value = text;
+            return result;
+         }
+         throw new Error("Bad response body!");
+      }
+
       body.sentences.forEach(function (obj)
       {
 


### PR DESCRIPTION
In some cases the response body only contains an array instead of a full object.
This commit will handle those cases and return a result with the translated text.

This has been tested on a new Discord server with 7 channels and with auto detection/translation.

![image](https://user-images.githubusercontent.com/983466/151068710-16618291-3795-4d0b-97f5-52240337516d.png)
